### PR TITLE
use decodeURIComponent to unescape request url

### DIFF
--- a/HumanGenerator.js
+++ b/HumanGenerator.js
@@ -39,7 +39,7 @@
       var request = this.request(paw_request);
 
 
-      var result = paw_request.method + ' ' + paw_request.url;
+      var result = paw_request.method + ' ' + decodeURIComponent(paw_request.url);
 
       if (request.headers.length) {
         result += '\n\n' + request.headers.map(function (header) {


### PR DESCRIPTION
Hi, first off thanks for this extension, its probably one of my most used in Paw 👍 

I'm working with an API that uses query params that are escaped by default in the current generator which results in some info being lost in translation when sharing requests in slack. This PR just uses `decodeURIComponent` to unescape the `paw_request.url` part of `result`

I'm not a JS dev so happy for feedback if this is not the best function to use. 

Example of request before change:

```
GET http://host.com/path?param_with_space=%22test%20space%22&filter=argwithtilde~%22value%22&list=%5Btest%5D&pipe=x%7Cy
```

And after change:

```
GET http://host.com/path?param_with_space="test space"&filter=argwithtilde~"value"&list=[test]&pipe=x|y
```
